### PR TITLE
Replace %%ARCH%% in Dockerfile

### DIFF
--- a/build-scripts/addons/create_hassio_addon.sh
+++ b/build-scripts/addons/create_hassio_addon.sh
@@ -138,6 +138,7 @@ DOCKER_TAG=$(jq --raw-output ".version" "$ADDON_WORKSPACE/config.json")
 DOCKER_IMAGE=$(jq --raw-output ".image // empty" "$ADDON_WORKSPACE/config.json")
 
 sed -i "s/%%BASE_IMAGE%%/${BASE_IMAGE}/g" "$ADDON_WORKSPACE/Dockerfile"
+sed -i "s/%%ARCH%%/${ARCH}/g" "$ADDON_WORKSPACE/Dockerfile"
 echo "LABEL io.hass.version=\"$DOCKER_TAG\" io.hass.arch=\"$ARCH\" io.hass.type=\"addon\"" >> "$ADDON_WORKSPACE/Dockerfile"
 
 # Run build


### PR DESCRIPTION
Replacing %%ARCH%% by ${ARCH} in addon Dockerfile allow to build an addon from an existing addon. It also allow some logic base on the arch in the Dockerfile. I'm using it for [mopidy_cast](https://github.com/bestlibre/hassio-addons/tree/master/mopidy_cast).