### PR TITLE
add needed boost packages for dlib component

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -43,7 +43,9 @@ RUN apk --no-cache add \
     bluez \
     curl \
     libsodium-dev \
-    openssh-client
+    openssh-client \
+    boost-dev \
+    boost-python
 
 ####
 ## Build library


### PR DESCRIPTION
Enabling image_processing.dlib_face_detect currently fails because the container is missing the needed boost libraries for face_recognition to compile dlib.

```
2017-06-30 14:45:04 WARNING (MainThread) [homeassistant.setup] Setup of image_processing is taking over 10 seconds.
2017-06-30 14:45:38 ERROR (SyncWorker_1) [homeassistant.util.package] Unable to install package face_recognition==0.1.14: Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-24t1vo7x/dlib/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-pjxzkd03-record/install-record.txt --single-version-externally-managed --compile --home=/tmp/tmpnqbxjful" failed with error code 1 in /tmp/pip-build-24t1vo7x/dlib/
2017-06-30 14:45:38 ERROR (MainThread) [homeassistant.setup] Not initializing image_processing.dlib_face_detect because could not install dependency face_recognition==0.1.14
2017-06-30 14:45:38 ERROR (MainThread) [homeassistant.setup] Unable to prepare setup for platform image_processing.dlib_face_detect: Could not install all requirements.

```