### PR TITLE
Removing enum34 to fix speedtest

### DIFF
--- a/homeassistant/generic/Dockerfile
+++ b/homeassistant/generic/Dockerfile
@@ -6,6 +6,7 @@ RUN echo "cryptography==1.9" >> homeassistant/requirements_all.txt \
     && sed -i "s/# face_recognition/face_recognition/g" homeassistant/requirements_all.txt \
     && pip3 install --no-cache-dir -r homeassistant/requirements_all.txt \
     && pip3 install --no-cache-dir /usr/src/homeassistant \
+    && pip3 uninstall -y enum34 \
     && rm -r homeassistant
 
 # Install and update certificate


### PR DESCRIPTION
Uninstalling enum34 which breaks speedtest component (similar to original HASS docker) 