### PR TITLE
Add symlinks to some RPi Cam utils so they are picked up in PATH.

### DIFF
--- a/homeassistant/machine/raspberrypi
+++ b/homeassistant/machine/raspberrypi
@@ -3,3 +3,10 @@ FROM homeassistant/armhf-homeassistant:%%VERSION%%
 LABEL io.hass.machine raspberrypi
 
 RUN apk --no-cache add raspberrypi raspberrypi-libs raspberrypi-dev usbutils
+
+##
+# Set symlinks for raspberry pi binaries.
+RUN ln -sv /opt/vc/bin/raspistill /usr/local/bin/raspistill \
+    && ln -sv /opt/vc/bin/raspivid /usr/local/bin/raspivid \
+    && ln -sv /opt/vc/bin/raspividyuv /usr/local/bin/raspividyuv \
+    && ln -sv /opt/vc/bin/raspiyuv /usr/local/bin/raspiyuv

--- a/homeassistant/machine/raspberrypi2
+++ b/homeassistant/machine/raspberrypi2
@@ -3,3 +3,11 @@ FROM homeassistant/armhf-homeassistant:%%VERSION%%
 LABEL io.hass.machine raspberrypi2
 
 RUN apk --no-cache add raspberrypi raspberrypi-libs raspberrypi-dev usbutils
+
+##
+# Set symlinks for raspberry pi binaries.
+RUN ln -sv /opt/vc/bin/raspistill /usr/local/bin/raspistill \
+    && ln -sv /opt/vc/bin/raspivid /usr/local/bin/raspivid \
+    && ln -sv /opt/vc/bin/raspividyuv /usr/local/bin/raspividyuv \
+    && ln -sv /opt/vc/bin/raspiyuv /usr/local/bin/raspiyuv
+

--- a/homeassistant/machine/raspberrypi3
+++ b/homeassistant/machine/raspberrypi3
@@ -3,3 +3,11 @@ FROM homeassistant/armhf-homeassistant:%%VERSION%%
 LABEL io.hass.machine raspberrypi3
 
 RUN apk --no-cache add raspberrypi raspberrypi-libs raspberrypi-dev usbutils
+
+##
+# Set symlinks for raspberry pi binaries.
+RUN ln -sv /opt/vc/bin/raspistill /usr/local/bin/raspistill \
+    && ln -sv /opt/vc/bin/raspivid /usr/local/bin/raspivid \
+    && ln -sv /opt/vc/bin/raspividyuv /usr/local/bin/raspividyuv \
+    && ln -sv /opt/vc/bin/raspiyuv /usr/local/bin/raspiyuv
+


### PR DESCRIPTION
This is to fix [#120](https://github.com/home-assistant/hassio/issues/120). Only the raspistill link is required to resolve this issue, however there are a couple of other utils for the RPi cam so these have been include also to allow for future component use.