### PR TITLE
Update README.md

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -17,13 +17,13 @@ curl
 Run as root:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -
+curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -s
 ```
 
 On a special platform they need set a machine type use:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash - -m MY_MACHINE
+curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -s -m MY_MACHINE
 ```
 
 ## Supported Machine types


### PR DESCRIPTION
I've tried installing on raspberrypi3 - bash there does not understand `-`, but understands standard `-s`.