### PR TITLE
Special platform command instruction did not work on raspberry 3

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -22,8 +22,7 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/in
 
 On a special platform they need set a machine type use:
 
-```bash
-curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash - -m MY_MACHINE
+```curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install > /var/tmp/hassio_install && chmod +x /var/tmp/hassio_install && /var/tmp/hassio_install -m $(uname -m)
 ```
 
 ## Supported Machine types


### PR DESCRIPTION
I realized the install instructions did not work for my raspberry pi, so this is the workaround I used. The install seem to have worked, but I haven't done any further verification than that.

```
root@pidesktop:~# curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash - -m $(uname -m)
bash: -m: No such file or directory
root@pidesktop:~# curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install > /var/tmp/hassio_install && chmod +x /var/tmp/hassio_install && /var/tmp/hassio_install -m $(uname -m)
[INFO] Install supervisor docker
[INFO] Install generic HostControl
[INFO] Install startup scripts
[INFO] Init systemd
Created symlink from /etc/systemd/system/multi-user.target.wants/hassio-supervisor.service to /etc/systemd/system/hassio-supervisor.service.
[INFO] Start services
root@pidesktop:~# docker ps
CONTAINER ID        IMAGE                                   COMMAND                  CREATED             STATUS              PORTS               NAMES
208ea1619c5a        homeassistant/armhf-hassio-supervisor   "/usr/bin/entry.sh..."   3 minutes ago       Up 3 minutes                            hassio_supervisor
root@pidesktop:~#
```