### PR TITLE
Fix syntax

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -336,7 +336,7 @@ while [[ $# -gt 0 ]]; do
         --no-cache)
             DOCKER_CACHE="false"
             ;;
-        -d, --docker-hub)
+        -d|--docker-hub)
             DOCKER_HUB=$2
             shift
             ;;


### PR DESCRIPTION
This has been introduced this morning with 2dc41ac01333a330caf0c3dee1d9d228c82c14dd and resulted in breaking the docker image 