### PR TITLE
Fix Mi Flora

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -138,8 +138,8 @@ RUN apk add --no-cache \
 ## Install gatttool from edge (can be removed with release of Alpine 3.7)
 RUN mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
-    $$ wget http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk \
+    && curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk \
     && tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool \
     && mv usr/bin/gatttool /usr/bin/ \
-    && cd ./../ \
-    && rm -r bluez-deprecated
+    && cd ../ \
+    && rm -fr bluez-deprecated

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -134,23 +134,17 @@ RUN apk add --no-cache \
         mariadb-dev postgresql-dev freetds-dev \
         gcc g++ musl-dev python3-dev make
 
-####
+
 ## Install gatttool from edge (can be removed with release of Alpine 3.7)
 ARG BUILD_ARCH
 RUN mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
-    && if [ "$BUILD_ARCH" = "amd64" ]; then APK_ARCH = "x86_64"; \
-       elif [ "$BUILD_ARCH" = "i386" ]; then APK_ARCH = "x86"; \
-       elif [ "$BUILD_ARCH" = "armhf" ]; then APK_ARCH = "armhf"; \
-       elif [ "$BUILD_ARCH" = "aarch64" ]; then APK_ARCH = "aarch64"; \
-       else exit 0; \ 
-    && if [ -z "$APK_ARCH"]; then cd ../; \
-            rm -fr bluez-deprecated; \ 
-            exit 0; \
-       else curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/$APK_ARCH/bluez-deprecated-5.47-r3.apk; \ 
-          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
-          mv usr/bin/gatttool /usr/bin/; \
-          cd ../; \
-          rm -fr bluez-deprecated; \
-          exit 0; \
+    && if [ "$BUILD_ARCH" = "amd64" ]; then APK_ARCH= "x86_64"; \
+       elif [ "$BUILD_ARCH" = "i386" ]; then APK_ARCH= "x86"; \
+       else APK_ARCH="$BUILD_ARCH"; \ 
+    && curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/$APK_ARCH/bluez-deprecated-5.47-r3.apk \ 
+    && tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool \
+    && mv usr/bin/gatttool /usr/bin/ \
+    && cd ../ \
+    && rm -fr bluez-deprecated
        

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -139,30 +139,18 @@ RUN apk add --no-cache \
 ARG BUILD_ARCH
 RUN mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
-    && if [ "$BUILD_ARCH" = "amd64" ]; then \
-          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/x86_64/bluez-deprecated-5.47-r3.apk; \ 
+    && if [ "$BUILD_ARCH" = "amd64" ]; then APK_ARCH = "x86_64"; \
+       elif [ "$BUILD_ARCH" = "i386" ]; then APK_ARCH = "x86"; \
+       elif [ "$BUILD_ARCH" = "armhf" ]; then APK_ARCH = "armhf"; \
+       elif [ "$BUILD_ARCH" = "aarch64" ]; then APK_ARCH = "aarch64"; \
+       else exit 0; \ 
+    && if [ -z "$APK_ARCH"]; then cd ../; \
+            rm -fr bluez-deprecated; \ 
+            exit 0; \
+       else curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/$APK_ARCH/bluez-deprecated-5.47-r3.apk; \ 
           tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
           mv usr/bin/gatttool /usr/bin/; \
           cd ../; \
           rm -fr bluez-deprecated; \
-       elif [ "$BUILD_ARCH" = "i386" ]; then \
-          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/x86/bluez-deprecated-5.47-r3.apk; \
-          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
-          mv usr/bin/gatttool /usr/bin/; \
-          cd ../; \
-          rm -fr bluez-deprecated; \      
-       elif [ "$BUILD_ARCH" = "armhf" ]; then \
-          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk; \
-          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
-          mv usr/bin/gatttool /usr/bin/; \
-          cd ../; \
-          rm -fr bluez-deprecated; \      
-       elif [ "$BUILD_ARCH" = "aarch64" ]; then \
-          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/aarch64/bluez-deprecated-5.47-r3.apk; \
-          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
-          mv usr/bin/gatttool /usr/bin/; \
-          cd ../; \
-          rm -fr bluez-deprecated; \      
-       else cd ../; \
-            rm- fr bluez-deprecated; \ 
-            exit 0; \
+          exit 0; \
+       

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -133,3 +133,13 @@ RUN apk add --no-cache \
     && apk del \
         mariadb-dev postgresql-dev freetds-dev \
         gcc g++ musl-dev python3-dev make
+
+####
+## Install gatttool from edge (can be removed with release of Alpine 3.7)
+RUN mkdir -p bluez-deprecated \
+    && cd bluez-deprecated \
+    $$ wget http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk \
+    && tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool \
+    && mv usr/bin/gatttool /usr/bin/ \
+    && cd ./../ \
+    && rm -r bluez-deprecated

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -136,10 +136,33 @@ RUN apk add --no-cache \
 
 ####
 ## Install gatttool from edge (can be removed with release of Alpine 3.7)
+ARG BUILD_ARCH
 RUN mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
-    && curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk \
-    && tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool \
-    && mv usr/bin/gatttool /usr/bin/ \
-    && cd ../ \
-    && rm -fr bluez-deprecated
+    && if [ "$BUILD_ARCH" = "amd64" ]; then \
+          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/x86_64/bluez-deprecated-5.47-r3.apk; \ 
+          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
+          mv usr/bin/gatttool /usr/bin/; \
+          cd ../; \
+          rm -fr bluez-deprecated; \
+       elif [ "$BUILD_ARCH" = "i386" ]; then \
+          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/x86/bluez-deprecated-5.47-r3.apk; \
+          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
+          mv usr/bin/gatttool /usr/bin/; \
+          cd ../; \
+          rm -fr bluez-deprecated; \      
+       elif [ "$BUILD_ARCH" = "armhf" ]; then \
+          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/armhf/bluez-deprecated-5.47-r3.apk; \
+          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
+          mv usr/bin/gatttool /usr/bin/; \
+          cd ../; \
+          rm -fr bluez-deprecated; \      
+       elif [ "$BUILD_ARCH" = "aarch64" ]; then \
+          curl -o bluez-deprecated-5.47-r3.apk http://dl-3.alpinelinux.org/alpine/edge/main/aarch64/bluez-deprecated-5.47-r3.apk; \
+          tar -xzf bluez-deprecated-5.47-r3.apk usr/bin/gatttool; \
+          mv usr/bin/gatttool /usr/bin/; \
+          cd ../; \
+          rm -fr bluez-deprecated; \      
+       else cd ../; \
+            rm- fr bluez-deprecated; \ 
+            exit 0; \


### PR DESCRIPTION
Extract missing gatttool which is needed by the Mi Flora component from the edge package.. This is a temporary fix until Alpine 3.7 is released.