### PR TITLE
Temporary fix for Mi Flora

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -119,8 +119,8 @@ RUN apk add --no-cache \
         readline \
     && apk add --no-cache --virtual .build-dependencies \
         gcc g++ make musl-dev consolekit dbus-dev libusb-compat-dev eudev-dev \
-	    libical-dev readline-dev glib-dev linux-headers \
-	    autoconf automake libtool \
+        libical-dev readline-dev glib-dev linux-headers \
+        autoconf automake libtool \
     && mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
     && curl -so bluez-5.44.tar.gz https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz \ 

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -112,3 +112,27 @@ RUN apk add --no-cache \
     && pip3 install --no-cache-dir https://github.com/wayfair/pymssql/archive/v2.1.3.0.0.1.zip \
     && pip3 install --no-cache-dir cchardet uvloop aiodns \
     && apk del .build-dependencies
+    
+####
+## Temporary Fix for Mi Flora. Remove on release of Alpine 3.7
+RUN apk add --no-cache \
+        gcc g++ make musl-dev consolekit dbus dbus-dev libusb-compat-dev eudev-dev \
+	libical-dev readline-dev glib-dev linux-headers \
+	autoconf automake libtool \
+    && mkdir -p bluez-deprecated \
+    && cd bluez-deprecated \
+    && curl -o bluez-5.44.tar.gz https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz \ 
+    && tar -xzf bluez-5.44.tar.gz \
+    && cd bluez-5.44 \
+    && ./configure \
+       --enable-deprecated \
+       --disable-systemd \
+       --enable-library \
+    && make \
+    && mv attrib/gatttool /usr/bin/ \
+    && cd ../../ \
+    && rm -fr bluez-deprecated \
+    && apk del \
+        gcc g++ make musl-dev consolekit dbus dbus-dev libusb-compat-dev eudev-dev \
+	libical-dev readline-dev glib-dev linux-headers \
+        autoconf automake libtool

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -116,12 +116,14 @@ RUN apk add --no-cache \
 ####
 ## Temporary Fix for Mi Flora. Remove on release of Alpine 3.7
 RUN apk add --no-cache \
-        gcc g++ make musl-dev consolekit dbus dbus-dev libusb-compat-dev eudev-dev \
-	libical-dev readline-dev glib-dev linux-headers \
-	autoconf automake libtool \
+        readline \
+    && apk add --no-cache --virtual .build-dependencies \
+        gcc g++ make musl-dev consolekit dbus-dev libusb-compat-dev eudev-dev \
+	    libical-dev readline-dev glib-dev linux-headers \
+	    autoconf automake libtool \
     && mkdir -p bluez-deprecated \
     && cd bluez-deprecated \
-    && curl -o bluez-5.44.tar.gz https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz \ 
+    && curl -so bluez-5.44.tar.gz https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz \ 
     && tar -xzf bluez-5.44.tar.gz \
     && cd bluez-5.44 \
     && ./configure \
@@ -132,7 +134,4 @@ RUN apk add --no-cache \
     && mv attrib/gatttool /usr/bin/ \
     && cd ../../ \
     && rm -fr bluez-deprecated \
-    && apk del \
-        gcc g++ make musl-dev consolekit dbus dbus-dev libusb-compat-dev eudev-dev \
-	libical-dev readline-dev glib-dev linux-headers \
-        autoconf automake libtool
+    && apk del .build-dependencies


### PR DESCRIPTION
We compile bluez with its' deprecated tools from source. This enables us to copy missing gatttool to /usr/bin.