### PR TITLE
Added armv6l architecture for raspberrypi 1 with raspbian

### DIFF
--- a/install/hassio_install
+++ b/install/hassio_install
@@ -67,7 +67,7 @@ case $ARCH in
         HOMEASSISTANT_DOCKER="$DOCKER_REPO/$MACHINE-homeassistant"
         HASSIO_DOCKER="$DOCKER_REPO/amd64-hassio-supervisor"
     ;;
-    "arm" | "armv7l")
+    "arm" | "armv7l" | "armv6l")
         if [ -z $MACHINE ]; then
             echo "[ERROR] Please set machine for $ARCH"
             exit 1


### PR DESCRIPTION
Installation didn't work on raspberrypi 1 without this change, as uname -a reports 
Linux raspberrypi 4.9.35+ #1014 Fri Jun 30 14:34:49 BST 2017 armv6l GNU/Linux