### PR TITLE
Add telldus-core to homeassistant-base

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -23,20 +23,6 @@ RUN apk add --no-cache \
 ## Build library
 WORKDIR /usr/src/
 
-### Install Telldus library for TellStick
-RUN apk add --no-cache \
-        confuse libftdi1 \
-    && apk add --no-cache --virtual .build-dependencies \
-        cmake build-base gcc doxygen confuse-dev argp-standalone libftdi1-dev git \
-    && git clone -b homeassistant-alpine https://github.com/bjorne/telldus.git \
-    && cd telldus/telldus-core \
-    && cmake . -DFORCE_COMPILE_FROM_TRUNK=YES \
-    && make \
-    && make install \
-    && cd ../.. \
-    && rm -rf telldus \
-    && apk del .build-dependencies
-
 # ssocr
 RUN apk add --no-cache git gcc make musl-dev imlib2-dev imlib2 \
     && git clone --depth 1 https://github.com/auerswal/ssocr \
@@ -99,6 +85,20 @@ RUN git clone --depth 1 -b v2.3.0 https://github.com/openalpr/openalpr \
         cmake ncurses make g++ tesseract-ocr-dev \
         git autoconf automake \
     && rm -rf /usr/src/openalpr
+
+### Install Telldus library for TellStick
+RUN apk add --no-cache \
+        confuse libftdi1 \
+    && apk add --no-cache --virtual .build-dependencies \
+        cmake build-base gcc doxygen confuse-dev argp-standalone libftdi1-dev git \
+    && git clone -b homeassistant-alpine https://github.com/bjorne/telldus.git \
+    && cd telldus/telldus-core \
+    && cmake . -DFORCE_COMPILE_FROM_TRUNK=YES \
+    && make \
+    && make install \
+    && cd ../.. \
+    && rm -rf telldus \
+    && apk del .build-dependencies
 
 ##
 # Install component packages

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -23,6 +23,20 @@ RUN apk add --no-cache \
 ## Build library
 WORKDIR /usr/src/
 
+### Install Telldus library for TellStick
+RUN apk add --no-cache \
+        confuse libftdi1 \
+    && apk add --no-cache --virtual .build-dependencies \
+        cmake build-base gcc doxygen confuse-dev argp-standalone libftdi1-dev git \
+    && git clone -b homeassistant-alpine https://github.com/bjorne/telldus.git \
+    && cd telldus/telldus-core \
+    && cmake . -DFORCE_COMPILE_FROM_TRUNK=YES \
+    && make \
+    && make install \
+    && cd ../.. \
+    && rm -rf telldus \
+    && apk del .build-dependencies
+
 # ssocr
 RUN apk add --no-cache git gcc make musl-dev imlib2-dev imlib2 \
     && git clone --depth 1 https://github.com/auerswal/ssocr \
@@ -114,19 +128,6 @@ RUN apk add --no-cache \
     && apk del .build-dependencies
     
 ####
-
-### Install Telldus library for TellStick
-# Couldn't find libftdi-compat in Alpine packages may be needed
-RUN apk add --no-cache --virtual .build-dependencies \
-        gcc g++ confuse cmake doxygen make git \
-    && git clone --depth 1 http://git.telldus.com/telldus.git \
-    && cd telldus/telldus-core \
-    && cmake -H. -Bbuild -DFORCE_COMPILE_FROM_TRUNK=YES \
-    && cd build \
-    && make \
-    && make install \
-    && apk del .build-dependencies \
-
 ## Temporary Fix for Mi Flora. Remove on release of Alpine 3.7
 RUN apk add --no-cache \
         readline \

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -114,6 +114,19 @@ RUN apk add --no-cache \
     && apk del .build-dependencies
     
 ####
+
+### Install Telldus library for TellStick
+# Couldn't find libftdi-compat in Alpine packages may be needed
+RUN apk add --no-cache --virtual .build-dependencies \
+        gcc g++ confuse cmake doxygen make git \
+    && git clone --depth 1 http://git.telldus.com/telldus.git \
+    && cd telldus/telldus-core \
+    && cmake -H. -Bbuild -DFORCE_COMPILE_FROM_TRUNK=YES \
+    && cd build \
+    && make \
+    && make install \
+    && apk del .build-dependencies \
+
 ## Temporary Fix for Mi Flora. Remove on release of Alpine 3.7
 RUN apk add --no-cache \
         readline \

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -91,14 +91,13 @@ RUN apk add --no-cache \
         confuse libftdi1 \
     && apk add --no-cache --virtual .build-dependencies \
         cmake build-base gcc doxygen confuse-dev argp-standalone libftdi1-dev git \
-    && git clone -b homeassistant-alpine https://github.com/bjorne/telldus.git \
+    && git clone -b homeassistant-alpine https://github.com/bjorne/telldus \
     && cd telldus/telldus-core \
     && cmake . -DFORCE_COMPILE_FROM_TRUNK=YES \
     && make \
     && make install \
-    && cd ../.. \
-    && rm -rf telldus \
-    && apk del .build-dependencies
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/telldus
 
 ##
 # Install component packages
@@ -146,6 +145,5 @@ RUN apk add --no-cache \
        --enable-library \
     && make \
     && mv attrib/gatttool /usr/bin/ \
-    && cd ../../ \
-    && rm -fr bluez-deprecated \
-    && apk del .build-dependencies
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/bluez-deprecated


### PR DESCRIPTION
`telldus-core` is needed for the `tellstick` component to work. Resolves home-assistant/hassio#225.

This builds a modified version of 2.1.3-beta1, adapted for Alpine, see https://github.com/bjorne/telldus/commit/687da09e5e09172204a98f5524ce737be196d0f9.

Please note that this is untested, and I've only tried building it for amd64 so far.

