### PR TITLE
Use telldus master branch instead of forked

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -95,9 +95,11 @@ RUN apk add --no-cache \
         confuse libftdi1 \
     && apk add --no-cache --virtual .build-dependencies \
         cmake build-base gcc doxygen confuse-dev argp-standalone libftdi1-dev git \
-    && git clone -b homeassistant-alpine --depth 1 https://github.com/bjorne/telldus \
+    && ln -s /usr/include/libftdi1/ftdi.h /usr/include/ftdi.h \
+    && git clone -b master --depth 1 https://github.com/telldus/telldus \
     && cd telldus/telldus-core \
-    && cmake . -DBUILD_LIBTELLDUS-CORE=ON -DBUILD_TDADMIN=OFF -DBUILD_TDTOOL=OFF -DGENERATE_MAN=OFF -DFORCE_COMPILE_FROM_TRUNK=ON \
+    && sed -i "/\<sys\/socket.h\>/a \#include \<sys\/select.h\>" common/Socket_unix.cpp \
+    && cmake . -DBUILD_LIBTELLDUS-CORE=ON -DBUILD_TDADMIN=OFF -DBUILD_TDTOOL=OFF -DGENERATE_MAN=OFF -DFORCE_COMPILE_FROM_TRUNK=ON -DFTDI_LIBRARY=/usr/lib/libftdi1.so \
     && make \
     && make install \
     && apk del .build-dependencies \


### PR DESCRIPTION
Instead of compiling from forked source i suggest to use telldus master branch and apply few patches in order to make it compile in alpine docker.
1) Symlink ftdi.h to /usr/include
2) Add line to include sys/select.h in Socket_unix.cpp to mitigate problems with timeval on compilation. 
3) Add cmake parameter for FTDI_LIBRARY to mitigate compilation issues with libftdi vs libftdi1. (symlinks will not solve this)