### PR TITLE
Merge when switching to Alpine Linux 3.7: Remove fix for Mi Flora

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -132,24 +132,3 @@ RUN apk add --no-cache \
     && pip3 install --no-cache-dir https://github.com/wayfair/pymssql/archive/v2.1.3.0.0.1.zip \
     && apk del .build-dependencies
     
-####
-## Temporary Fix for Mi Flora. Remove on release of Alpine 3.7
-RUN apk add --no-cache \
-        readline \
-    && apk add --no-cache --virtual .build-dependencies \
-        gcc g++ make musl-dev dbus-dev libusb-compat-dev eudev-dev \
-        libical-dev readline-dev glib-dev linux-headers \
-        autoconf automake libtool \
-    && mkdir -p bluez-deprecated \
-    && cd bluez-deprecated \
-    && curl -so bluez-5.44.tar.gz https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz \ 
-    && tar -xzf bluez-5.44.tar.gz \
-    && cd bluez-5.44 \
-    && ./configure \
-       --enable-deprecated \
-       --disable-systemd \
-       --enable-library \
-    && make \
-    && mv attrib/gatttool /usr/bin/ \
-    && apk del .build-dependencies \
-    && rm -rf /usr/src/bluez-deprecated


### PR DESCRIPTION
package bluez-deprecated should now contain gatttool therefore we don't need to build it ourself anymore