### PR TITLE
Fix test for local docker socket

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -106,7 +106,7 @@ function start_docker() {
     local starttime
     local endtime
 
-    if [ -f "/var/run/docker.sock" ]; then
+    if [ -e "/var/run/docker.sock" ]; then
         echo "[INFO] Use host docker setup with '/var/run/docker.sock'"
         DOCKER_LOCAL="true"
         return 0


### PR DESCRIPTION
The `-f` test checks if a given file is a "regular file". `docker.sock` will never be a regular file, since it is a socket! The "most correct" test for this would be `-S`, but `-e` is even looser, and I can't see a downside to using `-e`.

Documentation: http://wiki.bash-hackers.org/commands/classictest#file_tests

Proof of concept:

```bash
$ ls /var/run/docker.sock
/var/run/docker.sock
$ if [ -f /var/run/docker.sock ]; then echo "test passed"; fi
$ if [ -S /var/run/docker.sock ]; then echo "test passed"; fi
test passed
$ if [ -e /var/run/docker.sock ]; then echo "test passed"; fi
test passed
```