### PR TITLE
Added iperf3 to homeassistant Docker image

### DIFF
--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -104,9 +104,6 @@ RUN apk add --no-cache \
     && apk del .build-dependencies \
     && rm -rf /usr/src/telldus
 
-### Added Iperf3 support
-RUN apk add --no-cache iperf3
-
 ##
 # Install component packages
 RUN apk add --no-cache \
@@ -121,7 +118,8 @@ RUN apk add --no-cache \
     openssh-client \
     libffi \
     glib \
-    socat
+    socat \
+    iperf3
 
 ####
 ## Install pip module for component/homeassistant

--- a/homeassistant/base/Dockerfile
+++ b/homeassistant/base/Dockerfile
@@ -104,6 +104,9 @@ RUN apk add --no-cache \
     && apk del .build-dependencies \
     && rm -rf /usr/src/telldus
 
+### Added Iperf3 support
+RUN apk add --no-cache iperf3
+
 ##
 # Install component packages
 RUN apk add --no-cache \


### PR DESCRIPTION
Added support to `iperf3` on Alpine images to support `iperf3` sensor added in Home Assistant.

Documentation: https://github.com/home-assistant/home-assistant.github.io/pull/5282
Home Assistant PR: https://github.com/home-assistant/home-assistant/pull/14213