### PR TITLE
Add support for Orange Pi Prime

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -23,18 +23,20 @@ IMAGE=""
 BUILD_LIST=()
 BUILD_TYPE="addon"
 BUILD_TASKS=()
-declare -A BUILD_MACHINE=([odroid-c2]="aarch64" \
-                          [qemuarm-64]="aarch64" \
-                          [raspberrypi3-64]="aarch64" \
+declare -A BUILD_MACHINE=(
                           [intel-nuc]="amd64" \
-                          [qemux86-64]="amd64" \
+                          [odroid-c2]="aarch64" \
+                          [odroid-xu]="armhf" \
+                          [orangepi-prime]="aarch64" \
                           [qemuarm]="armhf" \
+                          [qemuarm-64]="aarch64" \
+                          [qemux86]="i386" \
+                          [qemux86-64]="amd64" \
                           [raspberrypi]="armhf" \
                           [raspberrypi2]="armhf" \
                           [raspberrypi3]="armhf" \
-                          [tinker]="armhf" \
-                          [odroid-xu]="armhf" \
-                          [qemux86]="i386")
+                          [raspberrypi3-64]="aarch64" \
+                          [tinker]="armhf" )
 
 
 #### Misc functions ####

--- a/install/README.md
+++ b/install/README.md
@@ -36,15 +36,16 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/in
 
 ## Supported Machine types
 
+- intel-nuc
+- odroid-c2
+- odroid-xu
+- orangepi-prime
+- qemuarm
+- qemuarm-64
+- qemux86
+- qemux86-64
 - raspberrypi
 - raspberrypi2
 - raspberrypi3
 - raspberrypi3-64
-- qemuarm
-- qemuarm-64
-- qemux86-64
-- qemux86
-- intel-nuc
 - tinker
-- odroid-c2
-- odroid-xu


### PR DESCRIPTION
This PR sorts the machine list alphabetically, and adds support for the Orange Pi Prime