### PR TITLE
doc(parameter): adds info about command line arguments to docs

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -28,7 +28,13 @@ Run as root (sudo su):
 curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -s
 ```
 
-On a special platform they need set a machine type use:
+### Command line arguments
+| argument           | default                                                                                                                                                                             | description                                            |
+|--------------------|-------------------|--------------------------------------------------------|
+| -m \| --machine    |                   | On a special platform they need set a machine type use |
+| -d \| --data-share | /usr/share/hassio | data folder for hass.io installation                   |
+
+you can set these parameters by appending ` -- <parameter> <value>` like:
 
 ```bash
 curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -s -- -m MY_MACHINE


### PR DESCRIPTION
since there is also an option to set another DATA_SHARE directory we
should add this information to the documentation. This can also serve
as a starting point for future command line arguments